### PR TITLE
Fix: Support for PostgreSQL 12.5

### DIFF
--- a/Dockerfile.postgres125
+++ b/Dockerfile.postgres125
@@ -1,0 +1,5 @@
+FROM instedd/hub:1.1-pre3
+
+ADD Rakefile /app/Rakefile
+
+ADD config/initializers/activerecord_monkeypatch_postgres125.rb /app/config/initializers/activerecord_monkeypatch_postgres125.rb

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,6 @@
 
 require File.expand_path('../config/application', __FILE__)
 
+require File.expand_path('./config/initializers/activerecord_monkeypatch_postgres125.rb')
+
 Rails.application.load_tasks

--- a/config/initializers/activerecord_monkeypatch_postgres125.rb
+++ b/config/initializers/activerecord_monkeypatch_postgres125.rb
@@ -1,0 +1,17 @@
+## Monkey-patch ActiveRecord to fix compatibility with PostgreSQL 12.5
+## See https://stackoverflow.com/a/61684855/641451
+
+require 'active_record/connection_adapters/postgresql_adapter'
+
+module ActiveRecord
+  module ConnectionAdapters
+    class PostgreSQLAdapter
+      def set_standard_conforming_strings
+        old, self.client_min_messages = client_min_messages, 'warning'
+        execute('SET standard_conforming_strings = on', 'SCHEMA') rescue nil
+      ensure
+        self.client_min_messages = old
+      end
+    end
+  end
+end


### PR DESCRIPTION
The Rails/ActiveRecord version we're using is not compatible with PostgreSQL 12.5.

This patch bypasses the main incompatibility.

Since the app is not building anymore due to dependencies issues, I'm building a
new production image based off on the previous one. We should fix this at some
time in the future.

```
docker build -f ./Dockerfile.postgres125 -t matiasgarciaisaia/instedd-hub:1.1-pre3-postgres12.5 .
```

See https://stackoverflow.com/a/61684855/641451